### PR TITLE
remove existing delegated event for this.selector

### DIFF
--- a/imagelightbox.js
+++ b/imagelightbox.js
@@ -268,7 +268,8 @@
                 }
             });
         }
-
+	
+	$( document ).off( 'click', this.selector);
         $( document ).on( 'click', this.selector, function( e )
         {
             if( !isTargetValid( this ) ) { return true; }


### PR DESCRIPTION
To prevent imagelightbox to fire up all lightboxes with the same selector of previously visited pages (on single page apps) simultaneously and show the images stacked on top of each other.

great work btw.
