### PR TITLE
Excluding build output from the typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
-  }
+  },
+  "exclude": ["dist", "docs"]
 }


### PR DESCRIPTION
`tsc --noEmit` here globs the whole project — there is no `include`, and no `outDir` to be excluded implicitly. After a local build that pulls the emitted declaration files into the program, so the typecheck covers its own output.

It is harmless (it passes either way) but it means a local typecheck does more work than needed and its file set depends on whether you have built. `dist/` and `docs/` are gitignored, so CI never hit it.

Verified: the build output files drop out of the program, every file under `src/` and `tests/` is still checked, and the typecheck and build both pass.