### PR TITLE
Pin the ES target to ES2017

### DIFF
--- a/docs.vite.config.ts
+++ b/docs.vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   build: {
     outDir: "../docs",
     sourcemap: true,
+    target: "es2017",
   },
   plugins: [istanbulPlugin({ include: "src/lib/**/*.ts" })],
   root: "src",

--- a/jquery.vite.config.ts
+++ b/jquery.vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       },
     },
     sourcemap: true,
+    target: "es2017",
   },
   plugins: [
     dts({

--- a/native.vite.config.ts
+++ b/native.vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       },
     },
     sourcemap: true,
+    target: "es2017",
   },
   plugins: [
     dts({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
+    "target": "es2017",
 
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
`tsconfig.json` set **no target at all**, so under TypeScript 6 it defaulted to ESNext, and the actual emit came from Vite 8's default `build.target` of `baseline-widely-available` — `chrome111, edge111, firefox114, safari16.4`, roughly ES2022.

Nothing about that level was chosen, and it drifts: Vite re-cuts its baseline snapshot on every major, so the published floor would move without anyone touching this repo.

## Why this package in particular

It is loaded straight into a browser, and the UMD build is **re-served verbatim by consumers**. `skaut-google-drive-gallery` copies `dist/imagelightbox.umd.cjs` into its own `dist/bundled/` and enqueues it with `wp_enqueue_script`, so this target sets the floor for that plugin's WordPress visitors, not just for us.

It also has **zero dependencies**, which makes it one of the few packages here whose own target genuinely is the whole constraint — there is no dependency tree quietly imposing a higher floor.

## Cost

Worth stating plainly, because it is not free:

| Bundle | before (gz) | after (gz) | |
|---|---|---|---|
| `imagelightbox.umd.cjs` | 3943 B | 4521 B | +578 B (+14.7%) |
| `imagelightbox.js` | 4375 B | 5099 B | +724 B (+16.5%) |
| `imagelightbox.jquery.umd.cjs` | 4371 B | 4930 B | +559 B (+12.8%) |

Almost all of it is the `??` / `?.` downlevel at the ES2020 boundary. There is no `async`/`await` anywhere in this codebase, so ES2015 would cost *exactly the same* as ES2017 — which is the reason to stop at ES2017 rather than going lower: below ES2020 the price is already paid in full, and ES2017 is the highest level that pays it.

## Verification

- `npm run lint` clean (eslint, stylelint, tsc, attw)
- `npx playwright test` — **189 tests pass** across Chromium, Firefox and WebKit, exercising the actual downlevelled bundle
- `?.` and `??` confirmed downlevelled in all three output bundles