### PR TITLE
Replace the ad-hoc browserslist with a Baseline floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,12 +78,8 @@
     "test": "nyc --reporter=lcov playwright test"
   },
   "browserslist": [
-    "cover 95%",
-    "> 0.5%",
-    "last 2 versions",
-    "Firefox ESR",
-    "not dead",
-    "not < 0.1%"
+    "baseline 2019",
+    "not edge 18"
   ],
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",


### PR DESCRIPTION
The old list was internally inconsistent rather than merely imprecise.

```
cover 95%, > 0.5%, last 2 versions, Firefox ESR, not dead, not < 0.1%
```

resolved to:

```
chrome 103, firefox 115, safari 16.6, ios_saf 11.0-11.2, edge 119
```

Claiming **iOS Safari 11 from 2017 while excluding Chrome 66 through 102.** The `cover 95%` term dragged in the iOS tail while the popularity terms kept the desktop floor modern, so the two halves described different eras and no coherent support policy.

## The floor

```json
"browserslist": ["baseline 2019", "not edge 18"]
```

Resolves to **chrome 66 / firefox 65 / safari 13 / ios 13 / edge 79** — consistent across engines, and matching the ES2017 target set in #1833.

It raises the iOS floor from 11 to 13 and lowers the desktop floor. That is the trade worth making: iOS 11 was the single term that made the old floor look arbitrary, and it is what I flagged early on as the only thing in the estate holding anything below ES2022.

`not edge 18` excludes legacy **EdgeHTML** — Baseline years include it, but it was discontinued in 2019 and force-migrated to Chromium in 2021. (`not dead` does not cover it.)

## This repo was the exception

Unlike the other five in this series, `eslint-plugin-compat` was **already effective** here — precisely because of that iOS 11 term. So this change is about coherence, not about switching a guard on.

It stays effective at the new floor:

```
structuredClone is not supported in Safari 13, iOS Safari 13.0-13.1, Firefox 65, Edge 79, Chrome 66
Object.hasOwn() is not supported in Safari 13, iOS Safari 13.0-13.1, Firefox 65, Edge 79, Chrome 66
Array.at() is not supported in Safari 13, iOS Safari 13.0-13.1, Firefox 65, Edge 79, Chrome 66
Object.fromEntries() is not supported in Chrome 66
```

And it is precise: `String.padStart` is correctly **not** flagged, being ES2017 and therefore within the floor.

## Why a Baseline year rather than the alternatives

**Rather than a version list** — one token that states a floor, nothing to hand-maintain per browser. That is what went wrong with the old list: six terms interacting in ways nobody could read off the page.

**Rather than `baseline widely available`** — it rolls upward on a 30-month schedule, so the floor of a published library would rise by calendar rather than by decision. It also lands on a higher ES level than this package targets.

## Verification

`npm run lint` clean before and after — eslint, stylelint, tsc and attw.
