### PR TITLE
Make the CSS compatibility rule an error

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,12 +5,7 @@ export default {
   rules: {
     "color-function-notation": "legacy",
     "media-feature-range-notation": "prefix",
-    "plugin/no-unsupported-browser-features": [
-      true,
-      {
-        severity: "warning",
-      },
-    ],
+    "plugin/no-unsupported-browser-features": true,
     "selector-class-pattern": "ilb-.*",
     "selector-id-pattern": "ilb-.*",
   },


### PR DESCRIPTION
`plugin/no-unsupported-browser-features` was `severity: "warning"`, so it could never fail CI. Now that #1835 gives it a real floor — `baseline 2019`, chrome 66 / firefox 65 / safari 13 — the rule can gate.

```diff
-    "plugin/no-unsupported-browser-features": [
-      true,
-      {
-        severity: "warning",
-      },
-    ],
+    "plugin/no-unsupported-browser-features": true,
```

No additional options needed — this repo reports **no findings at either severity**.

Part of why is the `media-feature-range-notation: "prefix"` rule already configured here: it keeps `@media` queries out of the `(width >= …)` range syntax that Safari only gained in 16.4. dedic.eu, which lacks that rule, has four such queries flagged.

## Verification

- `stylelint` clean on `src/**/*.css`
- `npm run lint` — 0 errors