### PR TITLE
Report needless stylelint disables

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "clean": "rimraf dist/* docs/*",
     "lint": "run-p -c --aggregate-output lint:*",
     "lint:css": "run-p -c --aggregate-output lint:css:*",
-    "lint:css:stylelint": "stylelint --color 'src/**/*.css'",
+    "lint:css:stylelint": "stylelint --color --report-needless-disables 'src/**/*.css'",
     "lint:eslint": "eslint --color",
     "lint:ts": "run-p -c --aggregate-output lint:ts:*",
     "lint:ts:attw": "attw --pack",


### PR DESCRIPTION
`--report-needless-disables` makes stylelint fail on a suppression that no longer suppresses anything.

```diff
-"lint:css:stylelint": "stylelint --color 'src/**/*.css'"
+"lint:css:stylelint": "stylelint --color --report-needless-disables 'src/**/*.css'"
```

Without it, a disable comment outlives its cause silently. The same flag found **21 dead suppressions** across the sibling repos — 18 in a single file in skaut-google-drive-gallery, on things like `box-shadow`, `border-radius` and `opacity` — and none of them carried a comment saying what they were for, so there was no way to notice they had expired.

This repo is already clean, so the flag changes nothing today. Its single disable — on `body` overflow in `container.css` — is genuinely needed and already explains itself:

```css
/* stylelint-disable-next-line plugin/no-unsupported-browser-features -- body will be scrollable in old browsers, there is no polyfill */
```

That comment is the model the other repos are being brought up to.

## Verification

`npm run lint:css` clean with the flag enabled.