### PR TITLE
Test on all supported Node versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,6 +76,9 @@ jobs:
     name: "Test"
     runs-on: ubuntu-latest
     needs: get-playwright-version
+    strategy:
+      matrix:
+        node-version: [22, 24, 26]
     container:
       image: >-
         mcr.microsoft.com/playwright:v${{
@@ -83,6 +86,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
+
+      - name: "Setup Node"
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: "Cache NPM dependencies"
         uses: actions/cache@v6
@@ -114,7 +122,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: playwright-report-jquery-${{ matrix.jquery-version }}
+          name: playwright-report-${{ matrix.node-version }}
           path: playwright-report/
           retention-days: 30
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "url": "https://dedic.eu/"
   },
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
Fixes #1834.

## What changed

- **`CI.yml` — `test` job**: matrix over the supported even Node majors (22, 24, 26), overriding the Playwright container's Node via `actions/setup-node`, so each version is actually exercised rather than relying on whatever Node the image ships.
- **Artifact-name fix**: the report upload referenced a non-existent `matrix.jquery-version` (always resolved to `playwright-report-jquery-`). Now keyed on `matrix.node-version` so the three legs upload distinct reports instead of colliding.
- **`package.json`**: added `engines.node: ">=22"` so the supported range is stated, matching the tested majors and the Vite 8 floor.

`build` and `lint` are left unchanged.