### PR TITLE
Remove rules already enabled by extended presets

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,7 +111,6 @@ export default tseslint.config(
       "no-useless-concat": "error",
       "no-useless-rename": "error",
       "no-useless-return": "error",
-      "no-var": "error",
       "no-void": ["error", { allowAsStatement: true }],
       "no-warning-comments": "warn",
       "object-shorthand": "error",
@@ -147,8 +146,6 @@ export default tseslint.config(
       "prefer-object-has-own": "error",
       "prefer-object-spread": "error",
       "prefer-regex-literals": "error",
-      "prefer-rest-params": "error",
-      "prefer-spread": "error",
       "prefer-template": "error",
       radix: "error",
       "require-atomic-updates": "error",
@@ -182,7 +179,6 @@ export default tseslint.config(
       "@typescript-eslint/no-unnecessary-parameter-property-assignment":
         "error",
       "@typescript-eslint/no-unnecessary-qualifier": "error",
-      "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-use-before-define": [
         "error",
         { functions: false },


### PR DESCRIPTION
Removes ESLint rules that are already enabled with the same value by the presets each block extends, so they were redundant. Verified per rule with ESLint's own config resolution that each removed rule still resolves to `error` for the relevant file types.

Categories removed (as applicable to this repo):
- main block: `no-var`, `prefer-rest-params`, `prefer-spread` (already set by typescript-eslint's strict/stylistic, which inherit the block's js+ts scope)
- type-checked block: `@typescript-eslint/no-unused-vars`, `@typescript-eslint/no-base-to-string` (already set by strict / strict-type-checked)
- vitest block: `vitest/no-interpolation-in-snapshots`, `vitest/no-mocks-import`, `vitest/valid-expect-in-promise` (already in vitest/recommended)
- svelte block: `svelte/prefer-writable-derived` (already in svelte flat/recommended)