### PR TITLE
Deploy docs to GitHub Pages directly from the workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,10 +2,21 @@
 name: "Deploy docs"
 "on":
   push:
-    branches:
-      - master
+    branches: "master"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 env:
   cache-version: 1
+
 jobs:
   build:
     name: "Build docs"
@@ -13,6 +24,9 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
+
+      - name: "Configure Pages"
+        uses: actions/configure-pages@v5
 
       - name: "Cache NPM dependencies"
         uses: actions/cache@v6
@@ -31,32 +45,21 @@ jobs:
 
       - name: "Build docs"
         run: |
-            npm run build:docs
+          npm run build:docs
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: "docs"
-          path: docs
+          path: "docs"
 
   deploy:
     name: "Deploy docs"
+    needs: "build"
     runs-on: ubuntu-latest
-    needs: build
+    environment:
+      name: "github-pages"
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: "Checkout"
-        uses: actions/checkout@v7
-
-      - name: "Download artifact"
-        uses: actions/download-artifact@v8
-        with:
-          name: "docs"
-          path: docs
-
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.9.0
-        with:
-          branch: gh-pages
-          folder: docs
-          clean: true
-          single-commit: true
+      - name: "Deploy to GitHub Pages"
+        id: "deployment"
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Switches GitHub Pages deployment from pushing to the `gh-pages` branch (via `JamesIves/github-pages-deploy-action`, served with the legacy "Deploy from a branch" source) to deploying the built artifact directly from the workflow using the official Pages actions.

## Changes
- Replace the separate build+push-to-`gh-pages` flow with `actions/configure-pages` + `actions/upload-pages-artifact` in the build job.
- Deploy job now uses `actions/deploy-pages` against the `github-pages` environment.
- Add the required `pages: write` / `id-token: write` permissions and a `pages` concurrency group.
- The docs build itself is unchanged.

## ⚠️ Required settings change (not in this PR)
Before/at merge, set **Settings → Pages → Source** to **GitHub Actions** (currently "Deploy from a branch" → `gh-pages`). The site will keep serving the old branch content until this is switched.

After merging and switching the source, the `gh-pages` branch is no longer used and can be deleted.